### PR TITLE
Fix using free variable issue

### DIFF
--- a/mo-git-blame.el
+++ b/mo-git-blame.el
@@ -574,7 +574,7 @@ from elisp.
 
 (defun mo-git-blame-run-blame-incrementally (start-line lines-to-blame)
   (let* ((num-content-lines (mo-git-blame-number-of-content-lines))
-         i)
+         i args)
     (dotimes (i (1- num-content-lines))
       (insert "\n"))
 


### PR DESCRIPTION
This also fixes following byte-compile warnings.

```
In mo-git-blame-run-blame-incrementally:
mo-git-blame.el:583:15:Warning: assignment to free variable `args'
mo-git-blame.el:584:28:Warning: reference to free variable `args'
```