### PR TITLE
Hi, would you like to review this change that improves a bit setting up the blame-window?

### DIFF
--- a/mo-git-blame.el
+++ b/mo-git-blame.el
@@ -157,6 +157,14 @@ option if this variable is non-nil."
                  (const :tag "If available" if-available)
                  (const :tag "Never" never)))
 
+(defcustom mo-git-blame-delete-other-windows nil
+  "Delete other windows before setting up the blame-window and the
+content-window if variable is non-nil."
+
+  :group 'mo-git-blame
+  :type '(choice (const :tag "Delete other windows" t)
+                 (const :tag "Don't delete other windows" nil)))
+
 ;; This function was taken from magit (called 'magit-trim-line' there).
 (defun mo-git-blame-trim-line (str)
   (cond ((string= str "")
@@ -681,8 +689,12 @@ blamed."
                 (cons (list :full-file-name (plist-get prior-vars :full-file-name)
                             :revision (plist-get prior-vars :current-revision))
                       prior-revisions))))
+    (when mo-git-blame-delete-other-windows
+      (delete-other-windows-internal))
     (if (window-full-width-p)
-        (split-window-horizontally mo-git-blame-blame-window-width))
+        (split-window-horizontally mo-git-blame-blame-window-width)
+      (shrink-window-horizontally (- (window-width)
+                                     mo-git-blame-blame-window-width)))
     (select-window (setq content-window (next-window)))
     (switch-to-buffer content-buffer)
     (select-window blame-window)


### PR DESCRIPTION
It improves in these two areas:

- When the blame-window does not have full width, shrink it horizontally according to `mo-git-blame-blame-window-width`. Without this change, blame-window just uses its current width, ignoring the customization.

- Add customizable variable `mo-git-blame-delete-other-windows`. When it is non-nil, delete other windows before setting up the blame- and content- windows. The default value is nil for backward compatibility. This helps when there are more than 2 windows in the selected frame.

Tested in Emacs version 24.5 on Mac OS X. This is the only version I have easy access to.